### PR TITLE
feat(details-layout): adjust details screen to left-to-right (LTR)

### DIFF
--- a/app/src/main/res/layout/fragment_movie_details.xml
+++ b/app/src/main/res/layout/fragment_movie_details.xml
@@ -22,14 +22,15 @@
         android:text="Movie Title"
         android:textSize="24sp"
         android:textStyle="bold"
-        android:gravity="start"/>
+        android:gravity="left"/>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:gravity="center_vertical"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:layoutDirection="ltr">
 
         <!-- Year -->
         <TextView
@@ -77,6 +78,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:orientation="horizontal"
+        android:layoutDirection="ltr"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
 
     <FrameLayout

--- a/app/src/main/res/layout/fragment_series_details.xml
+++ b/app/src/main/res/layout/fragment_series_details.xml
@@ -22,14 +22,15 @@
             android:text="Series Title"
             android:textSize="24sp"
             android:textStyle="bold"
-            android:gravity="start"/>
+            android:gravity="left"/>
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:gravity="center_vertical"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:layoutDirection="ltr">
 
             <!-- Year -->
             <TextView
@@ -92,6 +93,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:orientation="horizontal"
+            android:layoutDirection="ltr"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
 
         <FrameLayout


### PR DESCRIPTION
- Ensured `LinearLayout` and text elements align from left to right
- Set `android:layoutDirection="ltr"` for proper alignment
- Adjusted UI elements to maintain correct visual hierarchy
- Improved text readability and icon placement in details screen